### PR TITLE
Fix issue with using __DIR__

### DIFF
--- a/src/lkwdwrd/Composer/MULoaderPlugin.php
+++ b/src/lkwdwrd/Composer/MULoaderPlugin.php
@@ -167,7 +167,8 @@ class MULoaderPlugin implements PluginInterface, EventSubscriberInterface {
 		if ( $muRequireFile !== false ) {
 			file_put_contents(
 				$muPath . $muRequireFile,
-				"<?php\n" . self::getMuRequireGeneratedDocBlock() . "\n" . 'require_once __DIR__ . ' . "'${toLoader}';\n"
+				// Need to break up __DIR__ to stop this https://github.com/composer/composer/blob/32966a3b1d48bc01472a8321fd6472b44fad033a/src/Composer/Plugin/PluginManager.php#L193 occurring.
+				"<?php\n" . self::getMuRequireGeneratedDocBlock() . "\n" . 'require_once __DI' . 'R__ . ' . "'${toLoader}';\n"
 			);
 		}
 	}


### PR DESCRIPTION
Composer does a rudimentary search and replace on __DIR__ so even if a
string will get replaced. This breaks it up as per
https://github.com/lkwdwrd/wp-muplugin-loader/pull/12 to stop this
happening.