### PR TITLE
Add better support for symlinked mu-plugins

### DIFF
--- a/src/lkwdwrd/mu-loader.php
+++ b/src/lkwdwrd/mu-loader.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/util/loader.php';
 require_once __DIR__ . '/util/util.php';
 require_once __DIR__ . '/util/list-table.php';
+require_once __DIR__ . '/util/assets.php';
 
 /**
  * If we are not installing, run the `mu_loader()`

--- a/src/lkwdwrd/util/assets.php
+++ b/src/lkwdwrd/util/assets.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Methods used to ensure composer-based mu-plugins are always treated like normal mu-plugins.
+ *
+ * @license MIT
+ * @copyright Luke Woodward
+ * @package WP_MUPlugin_Loader
+ */
+namespace LkWdwrd\MU_Loader\Assets;
+
+/**
+ * Make sure symlinked mu-plugins can use `plugins_url` like physical plugins can.
+ *
+ * @param string $url    The full URL to the plugin asset.
+ * @param string $path   The relative path to the asset from the plugin location.
+ * @param string $plugin The absolute path to the file requesting the asset URL.
+ * @return string        The full URL to the plugin asset.
+ */
+function plugins_url( $url, $path, $plugin ) {
+	// If the relative file is within a known directory, return the URL as usual.
+	if ( strstr( $plugin, WPMU_PLUGIN_DIR ) || strstr( $plugin, WP_PLUGIN_DIR ) ) {
+		return $url;
+	}
+
+	// Extract the relative path from the URL for comparison.
+	$relative_path = str_replace( WP_PLUGIN_URL, '', $url );
+
+	// Only modify the URL if the path is to an existing mu plugin with the file existing.
+	if ( file_exists( WPMU_PLUGIN_DIR . $relative_path ) ) {
+		$url = WPMU_PLUGIN_URL . $relative_path;
+	}
+
+	return $url;
+}
+
+/**
+ * Filter URLs created by `plugins_url` to support symlinked content.
+ */
+add_filter(
+	'plugins_url',
+	__NAMESPACE__ . '\\plugins_url',
+	10,
+	3
+);

--- a/src/lkwdwrd/util/assets.php
+++ b/src/lkwdwrd/util/assets.php
@@ -16,7 +16,7 @@ namespace LkWdwrd\MU_Loader\Assets;
  * @param string $plugin The absolute path to the file requesting the asset URL.
  * @return string        The full URL to the plugin asset.
  */
-function plugins_url( $url, $path, $plugin ) {
+function plugins_url( $url, $path = '', $plugin = '' ) {
 	// If the relative file is within a known directory, return the URL as usual.
 	if ( strstr( $plugin, WPMU_PLUGIN_DIR ) || strstr( $plugin, WP_PLUGIN_DIR ) ) {
 		return $url;

--- a/src/lkwdwrd/util/loader.php
+++ b/src/lkwdwrd/util/loader.php
@@ -36,7 +36,10 @@ function mu_loader( $plugins = false, $ps = PS, $mudir = MUDIR ): void {
 		$plugins = get_muplugins();
 	}
 	foreach( $plugins as $plugin ) {
-		wp_register_plugin_realpath( $mudir . $ps . $plugin );
+		// Conditionally register the MU plugin in WordPress 3.9 or newer.
+		if ( function_exists( 'wp_register_plugin_realpath' ) ) {
+			wp_register_plugin_realpath( $mudir . $ps . $plugin );
+		}
 		require_once $mudir . $ps . $plugin;
 	}
 }

--- a/src/lkwdwrd/util/loader.php
+++ b/src/lkwdwrd/util/loader.php
@@ -36,6 +36,7 @@ function mu_loader( $plugins = false, $ps = PS, $mudir = MUDIR ): void {
 		$plugins = get_muplugins();
 	}
 	foreach( $plugins as $plugin ) {
+		wp_register_plugin_realpath( $mudir . $ps . $plugin );
 		require_once $mudir . $ps . $plugin;
 	}
 }

--- a/tests/phpunit/assets_Tests.php
+++ b/tests/phpunit/assets_Tests.php
@@ -1,0 +1,69 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use LkWdwrd\MU_Loader\Assets;
+
+class Assets_Tests extends TestCase {
+	/**
+	 * Name of the plugin in our tests.
+	 */
+    const PLUGIN_NAME = 'test-plugin';
+
+	/**
+	 * Include the necessary files.
+	 */
+	public function setUp(): void {
+		require_once PROJECT . '/util/assets.php';
+
+		define( 'WPMU_PLUGIN_DIR', __DIR__ . '/tmp/mu-plugins' );
+		define( 'WP_PLUGIN_DIR', __DIR__ . '/tmp/plugins' );
+		define( 'WPMU_PLUGIN_URL', 'https://example.com/mu-plugins' );
+		define( 'WP_PLUGIN_URL', 'https://example.com/plugins' );
+
+		parent::setUp();
+	}
+
+	/**
+	 * Remove any directories that may have been created during our tests run.
+	 */
+	public function tearDown(): void {
+		if ( file_exists( __DIR__ . '/tmp/mu-plugins/' . self::PLUGIN_NAME ) ) {
+			rmdir( __DIR__ . '/tmp/mu-plugins/' . self::PLUGIN_NAME );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * If a plugins url is already in a known directory, ensure it returns unchanged.
+	 */
+	public function test_plugins_url_returns_unchanged_url_if_relative_file_in_known_directory(): void {
+		$plugins_url = WPMU_PLUGIN_URL . '/' . self::PLUGIN_NAME;
+		$plugin_file = WPMU_PLUGIN_DIR . '/' . self::PLUGIN_NAME . '/' . self::PLUGIN_NAME . '.php';
+		self::assertEquals( $plugins_url, Assets\plugins_url( $plugins_url, '', $plugin_file ) );
+	}
+
+	/**
+	 * If a plugin does not exist in the mu directory, ensure it returns unchanged.
+	 */
+	public function test_plugins_url_returns_unchanged_url_if_no_existing_mu_plugin(): void {
+		$plugins_url = WP_PLUGIN_URL . '/' . self::PLUGIN_NAME;
+		self::assertEquals( $plugins_url, Assets\plugins_url( $plugins_url ) );
+	}
+
+	/**
+	 * If a plugin exists in the mu directory, ensure it returns an updated url.
+	 */
+	public function test_plugins_url_returns_updated_url_if_mu_plugin_exists(): void {
+		$plugins_url = WP_PLUGIN_URL . '/' . self::PLUGIN_NAME;
+
+		// Create the directory in our mu-plugins dir
+		if ( ! mkdir( $plugin_directory = WPMU_PLUGIN_DIR . '/' . self::PLUGIN_NAME ) && ! is_dir( $plugin_directory ) ) {
+			throw new \RuntimeException( sprintf( 'Directory "%s" was not created', $plugin_directory ) );
+		}
+
+		$mu_plugins_url = WPMU_PLUGIN_URL . '/' . self::PLUGIN_NAME;
+
+		self::assertEquals( $mu_plugins_url, Assets\plugins_url( $plugins_url ) );
+	}
+}


### PR DESCRIPTION
This PR introduces the `wp_register_plugin_realpath` function when loading mu-plugins, this should resolve a lot of potential path issues for mu-plugins that are symlinked into the mu-plugins directory.

That support is particularly useful in scenarios where both physical files, and symbolic links exist side by side, so you are unable to modify the `WPMU_PLUGINS_DIR` constant to get a first-class treatment of the files.

Alongside this, a filter for `plugins_url` is introduced in a new assets utility file. This handles the scenario where the physical location of a symbolically linked file is found outside the `WPMU_PLUGIN_DIR` path. (WordPress handles asset links properly when these paths match, but will default to `siteurl/wp-content/plugins/$path` if not, completely ignoring the concept of mu-plugins).

The filter verrifies that the path is not within either plugin or mu-plugin paths already, before verrifying that it is a URL to a physical file that exists within an mu-plugin before trying to convert the URL to the correct one.