### PR TITLE
Support PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"class": "LkWdwrd\\Composer\\MULoaderPlugin"
 	},
 	"require": {
-		"php": "^7.3",
+		"php": "^7.3 || ^8.0",
 		"composer-plugin-api": "^1.0 || ^2.0"
 	},
 	"require-dev" : {


### PR DESCRIPTION
I'm running PHP 8 in my server, so I submit this simple PR to add support for it.

I deployed it already (pointing to my feature branch) to my site in production, and it works alright.

Please notice: PHP 8.0 doesn't work for development, since the `require-dev`ed package [`codeclimate/php-test-reporter`](https://packagist.org/packages/codeclimate/php-test-reporter) is stuck on PHP 7.
