### PR TITLE
Makes the mu-plugin src directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,13 @@ If you work on Windows but use a Linux VM to run your development server, you ma
 	"force-unix-separator": true
 }
 ```
+
+## Modifying the src directory of the mu plugins
+
+You may wish to change the src directory you want the mu plugins to be loaded from. For example, on WordPress VIP projects 
+you may wish to load mu plugins from client-mu-plugins using this loader. To do this you can set a constant to tell the 
+mu plugin loader where your mu plugins are kept:
+
+```php
+define('MU_PLUGIN_LOADER_SRC_DIR', WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . '/');
+```

--- a/src/Util/loader.php
+++ b/src/Util/loader.php
@@ -24,7 +24,7 @@ namespace LkWdwrd\MuPluginLoader\Util;
 function mu_loader($plugins = false, $ps = DIRECTORY_SEPARATOR, $mudir = WPMU_PLUGIN_DIR): void
 {
     if (! $plugins) {
-        $plugins = get_muplugins();
+        $plugins = get_muplugins(ABSPATH, WP_PLUGIN_DIR, $mudir);
     }
     foreach ($plugins as $plugin) {
         // Conditionally register the MU plugin in WordPress 3.9 or newer.

--- a/src/mu-loader.php
+++ b/src/mu-loader.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/Util/assets.php';
  */
 if (! defined('WP_INSTALLING') || ! WP_INSTALLING) {
     // Run the loader unless installing
-    mu_loader();
+    mu_loader(false, DIRECTORY_SEPARATOR, defined('MU_PLUGIN_LOADER_SRC_DIR') ? MU_PLUGIN_LOADER_SRC_DIR : WPMU_PLUGIN_DIR);
 }
 
 /**


### PR DESCRIPTION
**Overview**
Makes the mu-plugin src directory configurable

**Description**
You may wish to change the src directory you want the mu plugins to be loaded from (for example on vip you may wish to load mu plugins from client-mu-plugins using this loader). To do this you can set a constant to tell the mu plugin loader where your mu-plugins are kept:

```php
define('MU_PLUGIN_LOADER_SRC_DIR', WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . '/');

```
