### PR TITLE
[FEATURE] Fire action on completion of mu_loader

### DIFF
--- a/src/Util/loader.php
+++ b/src/Util/loader.php
@@ -33,6 +33,8 @@ function mu_loader($plugins = false, $ps = DIRECTORY_SEPARATOR, $mudir = WPMU_PL
         }
         require_once $mudir . $ps . $plugin;
     }
+
+    do_action('lkwdwrd_mupluginloader_muplugins_loaded');
 }
 
 /**


### PR DESCRIPTION
Fires an action on completion of mu_loader. This will help deal with the scenario where functionality in one plugin depends on functionality in another plugin being loaded first.

Usage:

```
add_action(
    'muplugins_loaded', 
    static function() {
        // Insert code here 
    }
);
```