### PR TITLE
[FEATURE] Fire action on completion of mu_loader

### DIFF
--- a/src/lkwdwrd/util/loader.php
+++ b/src/lkwdwrd/util/loader.php
@@ -42,6 +42,8 @@ function mu_loader( $plugins = false, $ps = PS, $mudir = MUDIR ): void {
 		}
 		require_once $mudir . $ps . $plugin;
 	}
+
+	do_action('lkwdwrd_mupluginloader_muplugins_loaded');
 }
 
 /**


### PR DESCRIPTION
Fires an action on completion of mu_loader. This will help deal with the scenario where functionality in one plugin depends on functionality in another plugin being loaded first.

Usage:

```
add_action(
    'muplugins_loaded', 
    static function() {
        // Insert code here 
    }
);
```