### PR TITLE
[FIX] Set expiry for site transient

### DIFF
--- a/src/Util/loader.php
+++ b/src/Util/loader.php
@@ -104,7 +104,9 @@ function get_muloader_key(string $mudir = WPMU_PLUGIN_DIR): string
         if ($old_key) {
             delete_site_transient($old_key);
         }
-        set_site_transient('lkw_mu_loader_key', $key);
+        // Set the key to expire in a day, just so if the md5 scan matches
+        // new plugins will eventually be loaded
+        set_site_transient('lkw_mu_loader_key', $key, 60 * 60 * 24);
     }
     return $key;
 }

--- a/tests/Util/LoaderTest.php
+++ b/tests/Util/LoaderTest.php
@@ -188,7 +188,7 @@ class LoaderTest extends TestCase
         ]);
         WP_Mock::userFunction('set_site_transient', [
             'times' => 1,
-            'args' => [ 'lkw_mu_loader_key', $this->key ]
+            'args' => [ 'lkw_mu_loader_key', $this->key, 60 * 60 * 24 ]
         ]);
         // Run the test
         $result = Util\get_muloader_key();


### PR DESCRIPTION
Change Details
------------
The site transient had no expiry date, which meant that if no file changes were detecetd by `scandir($mudir)` then the old key would continue to be used. 

I have set this to have an expiry of 1 day so that if this does happen eventually new code will be loaded, but with a 1 day expiry the performance impact is minimal. 

An example of this happening is that if a file already exists in `mu-plugins` but doesn't have the appropriate **plugin name** comment then the file is included in the scandir results, but not loaded by WP because of the missing comment. A later change to add the comment to the file does not prompt the loader to load the file. 

Backout Plan
-----------
Revert of this commit will restore previous behaviour without impact.