### PR TITLE
[FEATURE] Add a filter for loaded plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,21 @@ mu plugin loader where your mu plugins are kept:
 ```php
 define('MU_PLUGIN_LOADER_SRC_DIR', WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . '/');
 ```
+
+## Filtering the mu plugins loaded
+
+You may wish to filer the mu plugins loaded by the mu plugin loader. WordPress does not provide any hook that is early enough
+to ensure that this filter is registered before the plugins are loaded, so filtering of this list should be applied immediately before the mu-loader is initialised. You can modify the `mu-require.php` file like the below, or create a new file that's alphabetically before `mu-require.php` file in your `mu-plugins` directory. 
+
+```php
+add_filter(
+    'lkwdwrd_mupluginloader_get_muplugins',
+    function ( array $plugins ):  array {
+        unset( $plugins['example/plugin.php'] );
+        return $plugins;
+    }
+);
+
+// Load the mu loader
+require_once 'vendor/boxuk/wp-muplugin-loader/src/mu-loader.php';
+```

--- a/src/Util/loader.php
+++ b/src/Util/loader.php
@@ -73,7 +73,18 @@ function get_muplugins(string $abs = ABSPATH, string $pdir = WP_PLUGIN_DIR, stri
         }
         set_site_transient($key, $plugins);
     }
-    return $plugins;
+
+    /**
+     * Filter the list of Must-Use plugins. This must be done very early, likely
+     * by creating a file in the `mu-plugins` directory which is alphabetically
+     * before this MU-Loader is loaded.
+     *
+     * @param string[] $plugins The list of Must-Use plugin files, relative to
+     *                         the Must-Use plugins directory.
+     *
+     * @return string[] The filtered list of Must-Use plugins.
+     */
+    return (array) apply_filters('lkwdwrd_mupluginloader_get_muplugins', $plugins);
 }
 
 /**


### PR DESCRIPTION
Change Details
----------------
Adds support for the MU plugins that are about to be loaded to be filtered.

Typically filtering of this list should be applied before the mu-loader is initialised.

```php
add_filter(
    'lkwdwrd_mupluginloader_get_muplugins',
    function ( array $plugins ):  array {
        unset( $plugins['example/plugin.php'] );
        return $plugins;
    }
);

require_once 'vendor/boxuk/wp-muplugin-loader/src/mu-loader.php';
```